### PR TITLE
put to_xml and from_xml on the OME class

### DIFF
--- a/src/ome_types/__init__.py
+++ b/src/ome_types/__init__.py
@@ -1,7 +1,3 @@
-import os
-from pathlib import Path
-from typing import Union
-
 try:
     from ._version import version as __version__
 except ImportError:
@@ -14,16 +10,7 @@ except ImportError:
         "Could not import 'ome_types.model.OME'.\nIf you are in a dev environment, "
         "you may need to run 'python -m src.ome_autogen'"
     ) from None
-from .schema import to_dict, to_xml, validate  # isort:skip
 
-__all__ = ["to_dict", "validate", "from_xml", "to_xml"]
+from . import schema  # isort:skip
 
-
-def from_xml(xml: Union[Path, str]) -> OME:  # type: ignore
-    xml = os.fspath(xml)
-    d = to_dict(xml)
-    for key in list(d.keys()):
-        if key.startswith(("xml", "xsi")):
-            d.pop(key)
-
-    return OME(**d)  # type: ignore
+__all__ = ["OME", "schema"]

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -5,7 +5,7 @@ from xml.dom import minidom
 import pytest
 from xmlschema.validators.exceptions import XMLSchemaValidationError
 
-from ome_types import from_xml, model, to_xml
+from ome_types import OME, model
 from ome_types.schema import NS_OME, URI_OME, get_schema
 
 # Import ElementTree from one central module to avoid problems passing Elements around,
@@ -73,9 +73,9 @@ def test_read(xml):
 
     if true_stem(xml) in SHOULD_RAISE_READ:
         with pytest.raises(XMLSchemaValidationError):
-            assert from_xml(xml)
+            assert OME.from_xml(xml)
     else:
-        assert from_xml(xml)
+        assert OME.from_xml(xml)
 
 
 @pytest.mark.parametrize("xml", xml_roundtrip, ids=true_stem)
@@ -106,7 +106,7 @@ def test_roundtrip(xml):
         return xml_out
 
     original = canonicalize(xml, True)
-    ours = canonicalize(to_xml(from_xml(xml)), False)
+    ours = canonicalize(OME.from_xml(xml).to_xml(), False)
     assert ours == original
 
 


### PR DESCRIPTION
modification for you to consider...  this puts most of the main functionality in the OME class namespace:

```python
from ome_types import OME

ome = OME.from_xml('path/to/ome.xml')
xml = ome.to_xml()
some_dict = ome.to_dic()
```